### PR TITLE
Automatically prepends site.baseurl to links with absolute paths

### DIFF
--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -217,8 +217,7 @@ INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.fre
 REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*?$!.freeze
 LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
-  puts payload.inspect
-  markdown_converter ||= site.find_converter_instance(CONVERTER_CLASS)
+  markdown_converter ||= doc.site.find_converter_instance(CONVERTER_CLASS)
   if markdown_converter.matches(doc.extname)
     puts doc.content
     doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -228,7 +228,7 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
         puts "1"
         fail if href =~ /\A#{URI::regexp(['http', 'https'])}\z/
         puts "2"
-        href = doc.site.baseurl + "/" + href
+        href = doc.site.baseurl.gsub!(/\/\Z/) + "/" + href.gsub!(/\A\//)
         puts "3"
         "[#{a}](#{href})"
       rescue

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -227,7 +227,7 @@ Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
   doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
     #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
     puts original
-    original
+    "foo"
     
   end
 end

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -214,13 +214,12 @@ end
 LINK_TEXT_REGEX = %r!(.*?)!.freeze
 FRAGMENT_REGEX = %r!(#.+?)?!.freeze
 INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
-REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*?$!.freeze
-LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
   markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
   if markdown_converter.matches(doc.extname)
-    doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
+    doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
       #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
+      puts Regexp.last_match
       "TODO"
     end
     puts doc.content

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -231,9 +231,6 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
         href = doc.site.baseurl.gsub!(/\/\Z/) + "/" + href.gsub!(/\A\//)
         puts "3"
         "[#{a}](#{href})"
-      rescue
-        puts "4"
-        original
       end
     end
     puts doc.content

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -223,12 +223,18 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
       a = Regexp.last_match[1]
       href = Regexp.last_match[2]
       begin
+        puts "HERE: #{href}"
         fail if href.start_with?("#")
+        puts "1"
         fail if href.kind_of?(URI::HTTP) 
+        puts "2"
         fail if href.kind_of?(URI::HTTPS)
+        puts "3"
         href = doc.site.baseurl + "/" + href
+        puts "4"
         "[#{a}](#{href})"
       rescue
+        puts "5"
         original
       end
     end

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -224,7 +224,7 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
       href = Regexp.last_match[2]
       begin
         fail if href.start_with?("#")
-        fail if href.kind_of?(URI::HTTP) or href.kind_of?(URI::HTTPS)
+        fail if (href.kind_of?(URI::HTTP) or href.kind_of?(URI::HTTPS))
         href = doc.site.baseurl + "/" + href
         "[#{a}](#{href})"
       rescue

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -223,16 +223,10 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
       a = Regexp.last_match[1]
       href = Regexp.last_match[2]
       begin
-        puts "HERE: #{href}"
-        fail if href.start_with?("#")
-        puts "1"
-        fail if href =~ /\A#{URI::regexp(['http', 'https'])}\z/
-        puts "2"
+        fail if !href.start_with?("/")
         href = doc.site.baseurl.gsub(/\/\Z/, "") + "/" + href.gsub(/\A\//, "")
-        puts "3"
         "[#{a}](#{href})"
       rescue
-        puts "4"
         original
       end
     end

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -226,10 +226,9 @@ end
 Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
   doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
     #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
-    puts original
-    "foo"
-    
+    "TODO"
   end
+  puts doc.content
 end
 
 # Remember list markers

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -226,9 +226,8 @@ end
 Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
   doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
     #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
-    "TODO"
+    puts "TODO"
   end
-  puts doc.content
 end
 
 # Remember list markers

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -211,7 +211,7 @@ Jekyll::Hooks.register :site, :after_reset do |site|
 end
 
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc|
-    puts doc.inspect
+    puts doc
 end
 
 # TODO: In offline mode, base64-encode images, embed CSS (in style tags) and JS (in script tags), a la

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -207,32 +207,29 @@ end
 
 # Configure site
 Jekyll::Hooks.register :site, :after_reset do |site|
-
-  #
   site.config = Jekyll::Utils.deep_merge_hashes(Jekyll::Utils.deep_merge_hashes(CS50::DEFAULTS, site.config), CS50::OVERRIDES)
+end
 
-  # TODO
-  # https://github.com/benbalter/jekyll-relative-links/blob/master/lib/jekyll-relative-links/generator.rb
-  if site.baseurl
-    Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
-      LINK_TEXT_REGEX = %r!(.*?)!
-      FRAGMENT_REGEX = %r!(#.+?)?!
-      INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!
-      markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
-      if markdown_converter.matches(doc.extname)
-        doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
-          a = Regexp.last_match[1]
-          href = Regexp.last_match[2]
-          if href.start_with?("/")
-            href = doc.site.baseurl + href
-            "[#{a}](#{href})"
-          else
-            original
-          end
-        end
-        puts doc.content
+# TODO
+# https://github.com/benbalter/jekyll-relative-links/blob/master/lib/jekyll-relative-links/generator.rb
+LINK_TEXT_REGEX = %r!(.*?)!.freeze
+FRAGMENT_REGEX = %r!(#.+?)?!.freeze
+INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
+Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
+  next if !doc.site.baseurl
+  markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
+  if markdown_converter.matches(doc.extname)
+    doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
+      a = Regexp.last_match[1]
+      href = Regexp.last_match[2]
+      if href.start_with?("/")
+        href = doc.site.baseurl + href
+        "[#{a}](#{href})"
+      else
+        original
       end
     end
+    puts doc.content
   end
 end
 

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -210,35 +210,6 @@ Jekyll::Hooks.register :site, :after_reset do |site|
   site.config = Jekyll::Utils.deep_merge_hashes(Jekyll::Utils.deep_merge_hashes(CS50::DEFAULTS, site.config), CS50::OVERRIDES)
 end
 
-# TODO
-# https://github.com/benbalter/jekyll-relative-links/blob/master/lib/jekyll-relative-links/generator.rb
-LINK_TEXT_REGEX = %r!(.*?)!.freeze
-FRAGMENT_REGEX = %r!(#.+?)?!.freeze
-INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
-Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
-  next if !doc.site.baseurl
-  markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
-  if markdown_converter.matches(doc.extname)
-    doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
-      a = Regexp.last_match[1]
-      href = Regexp.last_match[2]
-      begin
-        puts "HERE: #{href}"
-        fail if href.start_with?("#")
-        puts "1"
-        fail if href =~ /\A#{URI::regexp(['http', 'https'])}\z/
-        puts "2"
-        href = doc.site.baseurl.gsub(/\/\Z/, "") + "/" + href.gsub(/\A\//, "")
-        puts "3"
-        "[#{a}](#{href})"
-      rescue
-        puts "4"
-        original
-      end
-    end
-    puts doc.content
-  end
-end
 
 # TODO: In offline mode, base64-encode images, embed CSS (in style tags) and JS (in script tags), a la
 # https://github.com/jekyll/jekyll-mentions/blob/master/lib/jekyll-mentions.rb and

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -217,9 +217,12 @@ INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.fre
 REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*?$!.freeze
 LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc|
-  puts doc.content
-  doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
-    #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
+  markdown_converter ||= site.find_converter_instance(CONVERTER_CLASS)
+  if markdown_converter.matches(doc.extname)
+    puts doc.content
+    doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
+      #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
+    end
   end
 end
 

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -213,15 +213,29 @@ LINK_TEXT_REGEX = %r!(.*?)!.freeze
 FRAGMENT_REGEX = %r!(#.+?)?!.freeze
 INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
+
+  # If no site.baseurl
   next if !doc.site.baseurl
+
+  # If .md file
   markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
   if markdown_converter.matches(doc.extname)
+
+    # For each link
     doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
+
+      # []
       a = Regexp.last_match[1]
+
+      # ()
       href = Regexp.last_match[2]
+
+      # If absolute path, prepend site.baseurl
       if href.start_with?("/")
         href = doc.site.baseurl.gsub(/\/\Z/, "") + "/" + href.gsub(/\A\//, "")
         "[#{a}](#{href})"
+
+      # Else leave unchanged
       else
         original
       end

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -217,9 +217,9 @@ INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.fre
 REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*?$!.freeze
 LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc|
+  puts doc.content
   doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
     #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
-    puts "TODO"
   end
 end
 

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -219,10 +219,11 @@ LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
   markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
   if markdown_converter.matches(doc.extname)
-    puts doc.content
     doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
       #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
+      "TODO"
     end
+    puts doc.content
   end
 end
 

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -223,11 +223,15 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
       a = Regexp.last_match[1]
       href = Regexp.last_match[2]
       begin
+        puts "111"
         fail if href.start_with?("#")
+        puts "222"
         fail if href.kind_of?(URI::HTTP) or href.kind_of?(URI::HTTPS)
+        puts "333"
         href = URI.join(doc.site.baseurl, href)
         "[#{a}](#{href})"
       rescue
+        puts "444"
         original
       end
     end

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -223,7 +223,7 @@ end
 # https://github.com/jekyll/jekyll-mentions/blob/master/lib/jekyll-mentions.rb and
 # https://github.com/jekyll/jemoji/blob/master/lib/jemoji.rb
 Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
-  puts "HERE"
+  puts doc.content
   doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
     #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
     puts "TODO"

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -224,7 +224,8 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
       href = Regexp.last_match[2]
       begin
         fail if href.start_with?("#")
-        fail if (href.kind_of?(URI::HTTP) or href.kind_of?(URI::HTTPS))
+        fail if href.kind_of?(URI::HTTP) 
+        fail if href.kind_of?(URI::HTTPS)
         href = doc.site.baseurl + "/" + href
         "[#{a}](#{href})"
       rescue

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -223,7 +223,7 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
       a = Regexp.last_match[1]
       href = Regexp.last_match[2]
       begin
-        fail if href.start_with?("/")
+        fail if href.start_with?("#")
         fail if uri.kind_of?(URI::HTTP) or uri.kind_of?(URI::HTTPS)
         href = URI.join(doc.site.baseurl, href)
         "[#{a}](#{href})"

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -223,8 +223,10 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
       href = Regexp.last_match[2]
       if href.start_with?("/")
         href = doc.site.baseurl + href
+        "[#{a}](#{href})"
+      else
+        original
       end
-      "[#{a}](#{href})"
     end
     puts doc.content
   end

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -210,6 +210,12 @@ Jekyll::Hooks.register :site, :after_reset do |site|
   site.config = Jekyll::Utils.deep_merge_hashes(Jekyll::Utils.deep_merge_hashes(CS50::DEFAULTS, site.config), CS50::OVERRIDES)
 end
 
+LINK_TEXT_REGEX = %r!(.*?)!.freeze
+FRAGMENT_REGEX = %r!(#.+?)?!.freeze
+INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
+REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*?$!.freeze
+LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
+
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc|
     puts doc
 end
@@ -218,6 +224,12 @@ end
 # https://github.com/jekyll/jekyll-mentions/blob/master/lib/jekyll-mentions.rb and
 # https://github.com/jekyll/jemoji/blob/master/lib/jemoji.rb
 Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
+  doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
+    #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
+    puts original
+    original
+    
+  end
 end
 
 # Remember list markers

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -210,6 +210,35 @@ Jekyll::Hooks.register :site, :after_reset do |site|
   site.config = Jekyll::Utils.deep_merge_hashes(Jekyll::Utils.deep_merge_hashes(CS50::DEFAULTS, site.config), CS50::OVERRIDES)
 end
 
+# TODO
+# https://github.com/benbalter/jekyll-relative-links/blob/master/lib/jekyll-relative-links/generator.rb
+LINK_TEXT_REGEX = %r!(.*?)!.freeze
+FRAGMENT_REGEX = %r!(#.+?)?!.freeze
+INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
+Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
+  next if !doc.site.baseurl
+  markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
+  if markdown_converter.matches(doc.extname)
+    doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
+      a = Regexp.last_match[1]
+      href = Regexp.last_match[2]
+      begin
+        puts "HERE: #{href}"
+        fail if href.start_with?("#")
+        puts "1"
+        fail if href =~ /\A#{URI::regexp(['http', 'https'])}\z/
+        puts "2"
+        href = doc.site.baseurl.gsub(/\/\Z/, "") + "/" + href.gsub(/\A\//, "")
+        puts "3"
+        "[#{a}](#{href})"
+      rescue
+        puts "4"
+        original
+      end
+    end
+    puts doc.content
+  end
+end
 
 # TODO: In offline mode, base64-encode images, embed CSS (in style tags) and JS (in script tags), a la
 # https://github.com/jekyll/jekyll-mentions/blob/master/lib/jekyll-mentions.rb and

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -207,7 +207,15 @@ end
 
 # Configure site
 Jekyll::Hooks.register :site, :after_reset do |site|
+
+  #
   site.config = Jekyll::Utils.deep_merge_hashes(Jekyll::Utils.deep_merge_hashes(CS50::DEFAULTS, site.config), CS50::OVERRIDES)
+
+  if site.baseurl
+    puts "YES"
+    puts site.baseurl
+  end
+
 end
 
 # TODO
@@ -216,6 +224,7 @@ LINK_TEXT_REGEX = %r!(.*?)!.freeze
 FRAGMENT_REGEX = %r!(#.+?)?!.freeze
 INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
+  next if !doc.site.baseurl
   markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
   if markdown_converter.matches(doc.extname)
     doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -210,24 +210,17 @@ Jekyll::Hooks.register :site, :after_reset do |site|
   site.config = Jekyll::Utils.deep_merge_hashes(Jekyll::Utils.deep_merge_hashes(CS50::DEFAULTS, site.config), CS50::OVERRIDES)
 end
 
-LINK_TEXT_REGEX = %r!(.*?)!.freeze
-FRAGMENT_REGEX = %r!(#.+?)?!.freeze
-INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
-REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*?$!.freeze
-LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
-
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc|
+  doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
+    #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
+    puts "TODO"
+  end
 end
 
 # TODO: In offline mode, base64-encode images, embed CSS (in style tags) and JS (in script tags), a la
 # https://github.com/jekyll/jekyll-mentions/blob/master/lib/jekyll-mentions.rb and
 # https://github.com/jekyll/jemoji/blob/master/lib/jemoji.rb
 Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
-  puts doc.content
-  doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
-    #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
-    puts "TODO"
-  end
 end
 
 # Remember list markers

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -210,6 +210,10 @@ Jekyll::Hooks.register :site, :after_reset do |site|
   site.config = Jekyll::Utils.deep_merge_hashes(Jekyll::Utils.deep_merge_hashes(CS50::DEFAULTS, site.config), CS50::OVERRIDES)
 end
 
+Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc|
+    puts doc.inspect
+end
+
 # TODO: In offline mode, base64-encode images, embed CSS (in style tags) and JS (in script tags), a la
 # https://github.com/jekyll/jekyll-mentions/blob/master/lib/jekyll-mentions.rb and
 # https://github.com/jekyll/jemoji/blob/master/lib/jemoji.rb

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -219,7 +219,7 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
   if markdown_converter.matches(doc.extname)
     doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
       #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
-      puts Regexp.last_match
+        puts Regexp.last_match.inspect
       "TODO"
     end
     puts doc.content

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -217,7 +217,7 @@ INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.fre
 REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*?$!.freeze
 LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
-  markdown_converter ||= doc.site.find_converter_instance(CONVERTER_CLASS)
+  markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
   if markdown_converter.matches(doc.extname)
     puts doc.content
     doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -216,28 +216,27 @@ Jekyll::Hooks.register :site, :after_reset do |site|
     puts site.baseurl
   end
 
-end
-
-# TODO
-# https://github.com/benbalter/jekyll-relative-links/blob/master/lib/jekyll-relative-links/generator.rb
-LINK_TEXT_REGEX = %r!(.*?)!.freeze
-FRAGMENT_REGEX = %r!(#.+?)?!.freeze
-INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
-Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
-  next if !doc.site.baseurl
-  markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
-  if markdown_converter.matches(doc.extname)
-    doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
-      a = Regexp.last_match[1]
-      href = Regexp.last_match[2]
-      if href.start_with?("/")
-        href = doc.site.baseurl + href
-        "[#{a}](#{href})"
-      else
-        original
+  # TODO
+  # https://github.com/benbalter/jekyll-relative-links/blob/master/lib/jekyll-relative-links/generator.rb
+  LINK_TEXT_REGEX = %r!(.*?)!.freeze
+  FRAGMENT_REGEX = %r!(#.+?)?!.freeze
+  INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
+  Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
+    next if !doc.site.baseurl
+    markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
+    if markdown_converter.matches(doc.extname)
+      doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
+        a = Regexp.last_match[1]
+        href = Regexp.last_match[2]
+        if href.start_with?("/")
+          href = doc.site.baseurl + href
+          "[#{a}](#{href})"
+        else
+          original
+        end
       end
+      puts doc.content
     end
-    puts doc.content
   end
 end
 

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -224,7 +224,7 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
       href = Regexp.last_match[2]
       begin
         fail if href.start_with?("#")
-        fail if uri.kind_of?(URI::HTTP) or uri.kind_of?(URI::HTTPS)
+        fail if href.kind_of?(URI::HTTP) or href.kind_of?(URI::HTTPS)
         href = URI.join(doc.site.baseurl, href)
         "[#{a}](#{href})"
       rescue

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -216,7 +216,8 @@ FRAGMENT_REGEX = %r!(#.+?)?!.freeze
 INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
 REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*?$!.freeze
 LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
-Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc|
+Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
+  puts payload
   markdown_converter ||= site.find_converter_instance(CONVERTER_CLASS)
   if markdown_converter.matches(doc.extname)
     puts doc.content

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -222,10 +222,13 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
     doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
       a = Regexp.last_match[1]
       href = Regexp.last_match[2]
-      if href.start_with?("/")
-        href = doc.site.baseurl + href
+      begin
+        fail if href.start_with?("/")
+        fail if uri.kind_of?(URI::HTTP) or uri.kind_of?(URI::HTTPS)
+        href = URI.join(doc.site.baseurl, href)
         "[#{a}](#{href})"
-      else
+        else
+      rescue
         original
       end
     end

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -211,31 +211,27 @@ Jekyll::Hooks.register :site, :after_reset do |site|
   #
   site.config = Jekyll::Utils.deep_merge_hashes(Jekyll::Utils.deep_merge_hashes(CS50::DEFAULTS, site.config), CS50::OVERRIDES)
 
-  if site.baseurl
-    puts "YES"
-    puts site.baseurl
-  end
-
   # TODO
   # https://github.com/benbalter/jekyll-relative-links/blob/master/lib/jekyll-relative-links/generator.rb
-  LINK_TEXT_REGEX = %r!(.*?)!.freeze
-  FRAGMENT_REGEX = %r!(#.+?)?!.freeze
-  INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
-  Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
-    next if !doc.site.baseurl
-    markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
-    if markdown_converter.matches(doc.extname)
-      doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
-        a = Regexp.last_match[1]
-        href = Regexp.last_match[2]
-        if href.start_with?("/")
-          href = doc.site.baseurl + href
-          "[#{a}](#{href})"
-        else
-          original
+  if site.baseurl
+    Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
+      LINK_TEXT_REGEX = %r!(.*?)!
+      FRAGMENT_REGEX = %r!(#.+?)?!
+      INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!
+      markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
+      if markdown_converter.matches(doc.extname)
+        doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
+          a = Regexp.last_match[1]
+          href = Regexp.last_match[2]
+          if href.start_with?("/")
+            href = doc.site.baseurl + href
+            "[#{a}](#{href})"
+          else
+            original
+          end
         end
+        puts doc.content
       end
-      puts doc.content
     end
   end
 end

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -227,7 +227,6 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
         fail if uri.kind_of?(URI::HTTP) or uri.kind_of?(URI::HTTPS)
         href = URI.join(doc.site.baseurl, href)
         "[#{a}](#{href})"
-        else
       rescue
         original
       end

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -228,7 +228,7 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
         puts "1"
         fail if href =~ /\A#{URI::regexp(['http', 'https'])}\z/
         puts "2"
-        href = doc.site.baseurl.gsub!(/\/\Z/, "") + "/" + href.gsub!(/\A\//, "")
+        href = doc.site.baseurl.gsub(/\/\Z/, "") + "/" + href.gsub(/\A\//, "")
         puts "3"
         "[#{a}](#{href})"
       rescue

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -217,13 +217,13 @@ REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*
 LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
 
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc|
-    puts doc
 end
 
 # TODO: In offline mode, base64-encode images, embed CSS (in style tags) and JS (in script tags), a la
 # https://github.com/jekyll/jekyll-mentions/blob/master/lib/jekyll-mentions.rb and
 # https://github.com/jekyll/jemoji/blob/master/lib/jemoji.rb
 Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
+  puts "HERE"
   doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
     #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
     puts "TODO"

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -226,15 +226,13 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
         puts "HERE: #{href}"
         fail if href.start_with?("#")
         puts "1"
-        fail if href.kind_of?(URI::HTTP) 
+        fail if href =~ /\A#{URI::regexp(['http', 'https'])}\z/
         puts "2"
-        fail if href.kind_of?(URI::HTTPS)
-        puts "3"
         href = doc.site.baseurl + "/" + href
-        puts "4"
+        puts "3"
         "[#{a}](#{href})"
       rescue
-        puts "5"
+        puts "4"
         original
       end
     end

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -230,9 +230,6 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
         puts "333"
         href = URI.join(doc.site.baseurl, href)
         "[#{a}](#{href})"
-      rescue
-        puts "444"
-        original
       end
     end
     puts doc.content

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -217,7 +217,7 @@ INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.fre
 REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*?$!.freeze
 LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
-  puts payload
+  puts payload.inspect
   markdown_converter ||= site.find_converter_instance(CONVERTER_CLASS)
   if markdown_converter.matches(doc.extname)
     puts doc.content

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -210,6 +210,12 @@ Jekyll::Hooks.register :site, :after_reset do |site|
   site.config = Jekyll::Utils.deep_merge_hashes(Jekyll::Utils.deep_merge_hashes(CS50::DEFAULTS, site.config), CS50::OVERRIDES)
 end
 
+# TODO
+LINK_TEXT_REGEX = %r!(.*?)!.freeze
+FRAGMENT_REGEX = %r!(#.+?)?!.freeze
+INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
+REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*?$!.freeze
+LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!.freeze
 Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc|
   doc.content = doc.content.dup.gsub(LINK_REGEX) do |original|
     #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -228,9 +228,12 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
         puts "1"
         fail if href =~ /\A#{URI::regexp(['http', 'https'])}\z/
         puts "2"
-        href = doc.site.baseurl.gsub!(/\/\Z/) + "/" + href.gsub!(/\A\//)
+        href = doc.site.baseurl.gsub!(/\/\Z/, "") + "/" + href.gsub!(/\A\//, "")
         puts "3"
         "[#{a}](#{href})"
+      rescue
+        puts "4"
+        original
       end
     end
     puts doc.content

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -211,6 +211,7 @@ Jekyll::Hooks.register :site, :after_reset do |site|
 end
 
 # TODO
+# https://github.com/benbalter/jekyll-relative-links/blob/master/lib/jekyll-relative-links/generator.rb
 LINK_TEXT_REGEX = %r!(.*?)!.freeze
 FRAGMENT_REGEX = %r!(#.+?)?!.freeze
 INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!.freeze
@@ -218,9 +219,12 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
   markdown_converter ||= doc.site.find_converter_instance(Jekyll::Converters::Markdown)
   if markdown_converter.matches(doc.extname)
     doc.content = doc.content.dup.gsub(INLINE_LINK_REGEX) do |original|
-      #link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
-        puts Regexp.last_match.inspect
-      "TODO"
+      a = Regexp.last_match[1]
+      href = Regexp.last_match[2]
+      if href.start_with?("/")
+        href = doc.site.baseurl + href
+      end
+      "[#{a}](#{href})"
     end
     puts doc.content
   end

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -223,13 +223,12 @@ Jekyll::Hooks.register [:pages, :documents], :pre_render do |doc, payload|
       a = Regexp.last_match[1]
       href = Regexp.last_match[2]
       begin
-        puts "111"
         fail if href.start_with?("#")
-        puts "222"
         fail if href.kind_of?(URI::HTTP) or href.kind_of?(URI::HTTPS)
-        puts "333"
-        href = URI.join(doc.site.baseurl, href)
+        href = doc.site.baseurl + "/" + href
         "[#{a}](#{href})"
+      rescue
+        original
       end
     end
     puts doc.content


### PR DESCRIPTION
Implements https://github.com/cs50/jekyll-theme-cs50/issues/83.