### PR TITLE
Check to see if the hash is a text fragement.

### DIFF
--- a/assets/jekyll-theme-cs50.js
+++ b/assets/jekyll-theme-cs50.js
@@ -463,12 +463,16 @@ $(document).on('DOMContentLoaded', function() {
         if (!id) {
             return false;
         }
-        // Check to see if a text fragment
-        // If so, return false
-        if (id.slice(0, 3) === ":~:") {
+        if (id.startsWith('#:~:text=')) { // In case text fragment link
+            return false;
+        }        
+        let heading;
+        try {
+            heading = $('#' + id); // In case syntactically invalid ID
+        }
+        catch (err) {
             return false;
         }
-        const heading = $('#' + id);
         if (!heading.length) {
             return false;
         }

--- a/assets/jekyll-theme-cs50.js
+++ b/assets/jekyll-theme-cs50.js
@@ -463,6 +463,11 @@ $(document).on('DOMContentLoaded', function() {
         if (!id) {
             return false;
         }
+        // Check to see if a text fragment
+        // If so, return false
+        if (id.slice(0, 3) === ":~:") {
+            return false;
+        }
         const heading = $('#' + id);
         if (!heading.length) {
             return false;


### PR DESCRIPTION
Returns false if hash is actually a Text Fragment before trying to navigate to the assumed id of a header. Attempts to avoid the problem listed in #157. 