### PR TITLE
Fix Relative Paths in 404 Page by Skipping Post-Render Process

### DIFF
--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -466,6 +466,9 @@ Jekyll::Hooks.register [:site], :post_render do |site|
   # For each page
   site.pages.each do |page|
 
+    # Skip relative path logic for 404.md or 404.html
+    next if page.name == "404.md" || page.name == "404.html"    
+
     # If HTML
     if page.output_ext == ".html"
 


### PR DESCRIPTION
This pull request addresses the issue where relative paths in the 404 page (`404.md` or `404.html`) are incorrectly resolved for non-root URLs. The fix ensures that the 404 page uses absolute paths for assets by skipping the post-render process for these files.

### Changes
- Skip the post-render process for `404.md` or `404.html` to prevent incorrect relative path resolution.

### Impact
- Fixes the issue where accessing non-existent URLs at deeper levels (e.g., `/non/exist`) caused assets to fail to load.

### Related Issue
Closes #194.