### PR TITLE
Update usage of iFrameResize in theme's JS code.

### DIFF
--- a/assets/jekyll-theme-cs50.js
+++ b/assets/jekyll-theme-cs50.js
@@ -593,7 +593,7 @@ $(document).on('DOMContentLoaded', function() {
 
     // Resize iframes dynamically
     $('iframe').on('load', function() {
-        $(this).iFrameResize();
+        iFrameResize({}, this);
     });
 
     // Parse emoji

--- a/assets/jekyll-theme-cs50.js
+++ b/assets/jekyll-theme-cs50.js
@@ -593,7 +593,7 @@ $(document).on('DOMContentLoaded', function() {
 
     // Resize iframes dynamically
     $('iframe').on('load', function() {
-        iFrameResize({}, this);
+        iframeResize({}, this);
     });
 
     // Parse emoji

--- a/lib/jekyll-theme-cs50.rb
+++ b/lib/jekyll-theme-cs50.rb
@@ -466,6 +466,9 @@ Jekyll::Hooks.register [:site], :post_render do |site|
   # For each page
   site.pages.each do |page|
 
+    # Skip relative path logic for 404.md or 404.html
+    next if page.name == "404.md" || page.name == "404.html"    
+
     # If HTML
     if page.output_ext == ".html"
 


### PR DESCRIPTION
Update the usage of iframeResizer, and replace the deprecated `iFrameResize` with `iframeResize`.

Closes #196 