### PR TITLE
Update usage of iFrameResize in theme's JS code.

### DIFF
--- a/assets/jekyll-theme-cs50.js
+++ b/assets/jekyll-theme-cs50.js
@@ -593,7 +593,7 @@ $(document).on('DOMContentLoaded', function() {
 
     // Resize iframes dynamically
     $('iframe').on('load', function() {
-        $(this).iFrameResize();
+        iFrameResize({}, this);
     });
 
     // Parse emoji

--- a/assets/jekyll-theme-cs50.js
+++ b/assets/jekyll-theme-cs50.js
@@ -593,7 +593,7 @@ $(document).on('DOMContentLoaded', function() {
 
     // Resize iframes dynamically
     $('iframe').on('load', function() {
-        iFrameResize({}, this);
+        iframeResize({}, this);
     });
 
     // Parse emoji


### PR DESCRIPTION
Update the usage of iframeResizer, and replace the deprecated `iFrameResize` with `iframeResize`.

Closes #196 